### PR TITLE
socket 连接建立后使用异步循环的方式发送堆积包

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 \.nyc_output
 coverage
+.vscode
+package-lock.json

--- a/lib/easy_sock.js
+++ b/lib/easy_sock.js
@@ -208,6 +208,7 @@ function initSocket(cur){
 	var connect_timeout = cur.config.timeout ? cur.config.timeout * 3 : 3000;
 	
 	var connect_timer = setTimeout(function(){
+		console.log('tcp connect timeout!')
 		errorCall(new Error("easy_sock:TCP connect timeout(" + connect_timeout + ")"));
 		cur.socket = null;
 		cur.between_connect = false;
@@ -282,6 +283,7 @@ function initSocket(cur){
 		cur.between_connect = false;
        
 	}).on('close',function(){
+		console.log('client socket closed!!');
 		cur.between_close = false;
 		cur.socket = null;
         cur.isAlive = false;

--- a/lib/easy_sock.js
+++ b/lib/easy_sock.js
@@ -208,7 +208,6 @@ function initSocket(cur){
 	var connect_timeout = cur.config.timeout ? cur.config.timeout * 3 : 3000;
 	
 	var connect_timer = setTimeout(function(){
-		console.log('tcp connect timeout!')
 		errorCall(new Error("easy_sock:TCP connect timeout(" + connect_timeout + ")"));
 		cur.socket = null;
 		cur.between_connect = false;
@@ -222,12 +221,22 @@ function initSocket(cur){
 		cur.between_connect = false;
 		
 		//外部有可能会在发起连接但还没完成的时候发起请求，所以，把积累的请求都发了
-		var get;		
-		while(get = cur.tmpGetTaskList.shift()){
+		/* let get;
+		while(get = cur.tmpGetTaskList.shift()) {
 			get();
-		}		
+		} */
+
+		function asyncWhile() {
+			cur.tmpGetTaskList.shift()();
+			setImmediate(function () {
+				if (cur.tmpGetTaskList.length) {
+					asyncWhile();
+				}
+			})
+		}
+		asyncWhile();
 		
-	}).on('data', function(data) {		 	
+	}).on('data', function(data) {	
 		if (!data || !Buffer.isBuffer(data) || data.length <= 0 ){
 			//error
 			debug("buffer error:" + data);
@@ -283,7 +292,6 @@ function initSocket(cur){
 		cur.between_connect = false;
        
 	}).on('close',function(){
-		console.log('client socket closed!!');
 		cur.between_close = false;
 		cur.socket = null;
         cur.isAlive = false;

--- a/lib/easy_sock.js
+++ b/lib/easy_sock.js
@@ -228,7 +228,7 @@ function initSocket(cur){
 
 		function asyncWhile() {
 			cur.tmpGetTaskList.shift()();
-			setImmediate(function () {
+			setTimeout(function () {
 				if (cur.tmpGetTaskList.length) {
 					asyncWhile();
 				}

--- a/lib/easy_tcp_server.js
+++ b/lib/easy_tcp_server.js
@@ -1,5 +1,6 @@
 'use strict';
 const debug = require("debug")('easysock-server');
+let firstTime = true;
 
 /**
  * @param config
@@ -31,6 +32,15 @@ let exportee = module.exports = function (config, handleResponse) {
 	};
 
 	return function bindsocket(socket) {
+		if (firstTime) {
+			// sleep 310s，让客户端超时
+			let start = Date.now();
+			while (Date.now() - start < 310) {
+				continue;
+			}
+			firstTime = false;
+		}
+
 		debug('socket connected', socket.connection);
 
 		socket.on('data', data=> {

--- a/lib/easy_tcp_server.js
+++ b/lib/easy_tcp_server.js
@@ -1,6 +1,5 @@
 'use strict';
 const debug = require("debug")('easysock-server');
-let firstTime = true;
 
 /**
  * @param config
@@ -32,15 +31,6 @@ let exportee = module.exports = function (config, handleResponse) {
 	};
 
 	return function bindsocket(socket) {
-		if (firstTime) {
-			// sleep 310s，让客户端超时
-			let start = Date.now();
-			while (Date.now() - start < 310) {
-				continue;
-			}
-			firstTime = false;
-		}
-
 		debug('socket connected', socket.connection);
 
 		socket.on('data', data=> {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A easy and foolish way to develop a socket module, which is easy to use as well. Now support both TCP and UDP.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/ava test/tcp.test.js"
+    "test": "ava test/tcp.test.js"
   },
   "keywords": [
     "socket"

--- a/test/lib/simple-seq-client.js
+++ b/test/lib/simple-seq-client.js
@@ -14,6 +14,12 @@ module.exports = function (port, timeout) {
 			// console.log('client encode', data);
 			let body = new Buffer(data, 'utf-8');
 
+			// 假设encode需要50ms
+			let start = Date.now();
+			while(Date.now() - start < 50) {
+				continue
+			}
+
 			let packet = new Buffer(20);
 			//包头-start
 			packet.writeInt8(81, 0);	// Q

--- a/test/lib/simple-seq-client.js
+++ b/test/lib/simple-seq-client.js
@@ -1,13 +1,13 @@
 'use strict';
 const EasySock = require("../../index");
 
-module.exports = function (port) {
+module.exports = function (port, timeout) {
 	let easysock = new EasySock();
 	easysock.setConfig({
 		ip: "127.0.0.1",
 		port: port,
 		keepAlive: true,
-		timeout: 200    //0 by default
+		timeout: timeout || 200    //0 by default
 	});
 	Object.assign(easysock, {
 		encode: function (data, seq) {

--- a/test/tcp.test.js
+++ b/test/tcp.test.js
@@ -106,7 +106,7 @@ ava.serial('并行请求，有超时失败率', async function (t) {
 	let port = 9094;
 	await forkServer(port);
 
-	let easysock = createClient(port, 130); // tcp有可能拼两个包一起返回
+	let easysock = createClient(port, 120); // tcp有可能拼两个包一起返回
 
 	const Number = 5;
 	let failedTime = 0;

--- a/test/tcp.test.js
+++ b/test/tcp.test.js
@@ -102,8 +102,30 @@ let createServer = require("./lib/simple-seq-server");
 		t.is(data, 'hehe');
 	}
 }); */
+ava.serial('并行请求，有超时失败率', async function (t) {
+	let port = 9090 + Math.floor(Math.random() * 100);
+	await forkServer(port);
 
-ava.serial('并行请求，一次性压入多次写操作，触发死循环', async function (t) {
+	let easysock = createClient(port, 100);
+
+	const Number = 5;
+	t.plan(Number)
+
+	for (let i = 0; i < Number; i++) {
+		easysock.write('hehe' + i, function (err, data) {
+			console.log(err, data)
+			t.is(typeof data === 'string' && data.indexOf('hehe') !== -1, true)
+		})
+	}
+
+	return await new Promise(rs => {
+		setTimeout(() => {
+			rs()
+		}, 1000);
+	})
+})
+
+ava.serial('第一次连接超时，在close之前创建新连接，触发死循环', async function (t) {
 	let port = 9090 + Math.floor(Math.random() * 100);
 	await forkServer(port);
 


### PR DESCRIPTION
对于等待队列tmpGetTaskList，原有代码采取同步的方式清除队列。这样会卡死CPU，甚至有死循环的风险。因此更改为异步的方式，使用setTimeout实现。

不用process.nextTick是因为nextTick也会阻塞eventLoop。